### PR TITLE
Change DriveConstraints object to MecanumConstraints

### DIFF
--- a/src/main/kotlin/TrajectoryGen.kt
+++ b/src/main/kotlin/TrajectoryGen.kt
@@ -3,15 +3,23 @@ import com.acmerobotics.roadrunner.geometry.Vector2d
 import com.acmerobotics.roadrunner.trajectory.Trajectory
 import com.acmerobotics.roadrunner.trajectory.TrajectoryBuilder
 import com.acmerobotics.roadrunner.trajectory.constraints.DriveConstraints
+import com.acmerobotics.roadrunner.trajectory.constraints.MecanumConstraints
 
 object TrajectoryGen {
-    private val constraints = DriveConstraints(45.0, 60.0, 0.0, 270.0.toRadians, 270.0.toRadians, 0.0)
+    // Remember to set these constraints to the same values as your DriveConstants.java file in the quickstart
+    private val driveConstraints = DriveConstraints(60.0, 60.0, 0.0, 270.0.toRadians, 270.0.toRadians, 0.0)
+
+    // Remember to set your track width to an estimate of your actual bot to get accurate trajectory profile duration!
+    private const val trackWidth = 16.0
+
+    private val combinedConstraints = MecanumConstraints(driveConstraints, trackWidth)
+
     private val startPose = Pose2d(-48.0, -48.0, 90.0.toRadians)
 
     fun createTrajectory(): ArrayList<Trajectory> {
         val list = ArrayList<Trajectory>()
 
-        val builder1 = TrajectoryBuilder(startPose, startPose.heading, constraints)
+        val builder1 = TrajectoryBuilder(startPose, startPose.heading, combinedConstraints)
 
         builder1.forward(40.0);
 


### PR DESCRIPTION
Leaving it to DriveConstraints results in inaccurate profile durations. Switch to MecanumConstraints as that's what the quickstart uses by default if you're using SampleMecanumDrive.